### PR TITLE
Update remote docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.06.0-ce
+          version: 19.03.13
           docker_layer_caching: false
       - run:
           name: Prep local env variables for docker compose
@@ -91,7 +91,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.06.0-ce
+          version: 19.03.13
           docker_layer_caching: false
       - run:
           name: Prep files
@@ -120,7 +120,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.06.0-ce
+          version: 19.03.13
           docker_layer_caching: false
       - run:
           name: Generate report
@@ -137,7 +137,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.06.0-ce
+          version: 19.03.13
           docker_layer_caching: false
       - restore_cache:
           keys:
@@ -159,7 +159,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.06.0-ce
+          version: 19.03.13
           docker_layer_caching: false
       - run:
           name: Run PHPCS
@@ -175,7 +175,7 @@ jobs:
       - checkout
       - notify_status_poller/install_aws_cli
       - setup_remote_docker:
-          version: 18.06.0-ce
+          version: 19.03.13
           docker_layer_caching: false
       - notify_status_poller/ecr_login
       - run:


### PR DESCRIPTION
Per - https://discuss.circleci.com/t/old-linux-machine-image-remote-docker-deprecation/37572

Remote Docker version 18.06.0-ce is to be deprecated.

Replaced with latest version - 19.03.13