### PR TITLE
SW-5312 add email statuses to mapper and tidy up tests and coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,17 +52,9 @@ jobs:
       - name: Run composer install
         run: composer install -n --prefer-dist
       
-      - name: Run Unit Tests
-        run: |
-          php \
-            -dpcov.enabled=1 \
-            -dpcov.directory=./ \
-            -dpcov.exclude=\"~./vendor~\" \
-            ./vendor/bin/phpunit \
-            --configuration=./tests/phpunit.xml \
-            --coverage-text \
-            --log-junit=./test-results/unit/results.xml \
-            --testsuite=unit
+      - name: Run Unit Tests Docker
+        run:  docker-compose --project-name notify-status-poller run --rm test
+
       - name: Check Coverage
         run: |
           php -f scripts/coverage-checker.php test-results/clover/results.xml 100

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     cp local.env.example local.env
     
     # Install dependencies on your host machine
-    phpqa composer install --prefer-dist --no-interaction --no-scripts
+    composer install --prefer-dist --no-interaction --no-scripts
     
     # Update the local.env file with any secret credentials when testing external services
     docker-compose build job-runner

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     command:
       - "php"
       - "-dpcov.enabled=1"
-      - "-dpcov.directory=."
+      - "-dpcov.directory=/app"
       - "-dpcov.exclude=\"~vendor~\""
       - "/app/vendor/bin/phpunit"
       - "--configuration=/app/tests/phpunit.xml"

--- a/src/NotifyStatusPoller/Mapper/NotifyStatus.php
+++ b/src/NotifyStatusPoller/Mapper/NotifyStatus.php
@@ -13,20 +13,20 @@ class NotifyStatus
     public const SIRIUS_POSTING = 'posting';
     public const SIRIUS_POSTED = 'posted';
 
-    public const PENDING_VIRUS_CHECK = 'pending-virus-check';
-    public const VIRUS_SCAN_FAILED = 'virus-scan-failed';
-    public const VALIDATION_FAILED = 'validation-failed';
-    public const FAILED = 'failed';
-    public const ACCEPTED = 'accepted';
-    public const RECEIVED = 'received';
-
     public const STATUSES = [
-        self::FAILED => self::SIRIUS_REJECTED,
-        self::VIRUS_SCAN_FAILED => self::SIRIUS_REJECTED,
-        self::VALIDATION_FAILED => self::SIRIUS_REJECTED,
-        self::PENDING_VIRUS_CHECK => self::SIRIUS_QUEUED,
-        self::ACCEPTED => self::SIRIUS_POSTING,
-        self::RECEIVED => self::SIRIUS_POSTED,
+        'failed' => self::SIRIUS_REJECTED,
+        'virus-scan-failed' => self::SIRIUS_REJECTED,
+        'validation-failed' => self::SIRIUS_REJECTED,
+        'pending-virus-check' => self::SIRIUS_QUEUED,
+        'accepted' => self::SIRIUS_POSTING,
+        'received' => self::SIRIUS_POSTED,
+        'cancelled' => self::SIRIUS_REJECTED,
+        'technical-failure' => self::SIRIUS_REJECTED,
+        'permanent-failure' => self::SIRIUS_REJECTED,
+        'temporary-failure' => self::SIRIUS_REJECTED,
+        'created' => self::SIRIUS_POSTING,
+        'sending' => self::SIRIUS_POSTING,
+        'delivered' => self::SIRIUS_POSTED
     ];
 
     public function toSirius(string $notifyStatus): string

--- a/tests/NotifyStatusPollerTest/Unit/Command/Handler/UpdateDocumentStatusHandlerTest.php
+++ b/tests/NotifyStatusPollerTest/Unit/Command/Handler/UpdateDocumentStatusHandlerTest.php
@@ -110,7 +110,7 @@ class UpdateDocumentStatusHandlerTest extends TestCase
     {
         return new UpdateDocumentStatus([
             'notifyId' => '1',
-            'notifyStatus' => NotifyStatus::ACCEPTED,
+            'notifyStatus' => NotifyStatus::SIRIUS_POSTING,
             'documentId' => '4545',
         ]);
     }

--- a/tests/NotifyStatusPollerTest/Unit/Mapper/NotifyStatusTest.php
+++ b/tests/NotifyStatusPollerTest/Unit/Mapper/NotifyStatusTest.php
@@ -35,6 +35,13 @@ class NotifyStatusTest extends TestCase
             ['pending-virus-check', 'queued'],
             ['accepted', 'posting'],
             ['received', 'posted'],
+            ['cancelled', 'rejected'],
+            ['technical-failure', 'rejected'],
+            ['permanent-failure', 'rejected'],
+            ['temporary-failure', 'rejected'],
+            ['created', 'posting'],
+            ['sending', 'posting'],
+            ['delivered', 'posted'],
         ];
     }
 


### PR DESCRIPTION
This PR is to add the email statuses to be mapped to the Sirius statuses that exist as well fixing associated tests and fixing coverage.