### PR TITLE
SW-5312 add email statuses to mapper and tidy up tests and coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,16 +53,8 @@ jobs:
         run: composer install -n --prefer-dist
 
       - name: Run Unit Tests
-        run: |
-          php \
-            -dpcov.enabled=1 \
-            -dpcov.directory=./ \
-            -dpcov.exclude=\"~./vendor~\" \
-            ./vendor/bin/phpunit \
-            --configuration=./tests/phpunit.xml \
-            --coverage-text \
-            --log-junit=./test-results/unit/results.xml \
-            --testsuite=unit
+        run: docker-compose --project-name notify-status-poller run --rm test
+
       - name: Check Coverage
         run: |
           php -f scripts/coverage-checker.php test-results/clover/results.xml 100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     command:
       - "php"
       - "-dpcov.enabled=1"
-      - "-dpcov.directory=."
+      - "-dpcov.directory=/app"
       - "-dpcov.exclude=\"~vendor~\""
       - "/app/vendor/bin/phpunit"
       - "--configuration=/app/tests/phpunit.xml"

--- a/src/NotifyStatusPoller/Mapper/NotifyStatus.php
+++ b/src/NotifyStatusPoller/Mapper/NotifyStatus.php
@@ -22,6 +22,11 @@ class NotifyStatus
     public const CANCELLED = 'cancelled';
     public const TECHNICAL_FAILURE = 'technical-failure';
     public const PERMANENT_FAILURE = 'permanent-failure';
+    public const TEMPORARY_FAILURE = 'temporary-failure';
+
+    public const CREATED = 'created';
+    public const SENDING = 'sending';
+    public const DELIVERED = 'delivered';
 
     public const STATUSES = [
         self::FAILED => self::SIRIUS_REJECTED,
@@ -33,6 +38,10 @@ class NotifyStatus
         self::CANCELLED => self::SIRIUS_REJECTED,
         self::TECHNICAL_FAILURE => self::SIRIUS_REJECTED,
         self::PERMANENT_FAILURE => self::SIRIUS_REJECTED,
+        self::TEMPORARY_FAILURE => self::SIRIUS_REJECTED,
+        self::CREATED => self::SIRIUS_POSTING,
+        self::SENDING => self::SIRIUS_POSTING,
+        self::DELIVERED => self::SIRIUS_POSTED
     ];
 
     public function toSirius(string $notifyStatus): string

--- a/tests/NotifyStatusPollerTest/Unit/Mapper/NotifyStatusTest.php
+++ b/tests/NotifyStatusPollerTest/Unit/Mapper/NotifyStatusTest.php
@@ -38,6 +38,10 @@ class NotifyStatusTest extends TestCase
             ['cancelled', 'rejected'],
             ['technical-failure', 'rejected'],
             ['permanent-failure', 'rejected'],
+            ['temporary-failure', 'rejected'],
+            ['created', 'posting'],
+            ['sending', 'posting'],
+            ['delivered', 'posted'],
         ];
     }
 


### PR DESCRIPTION
This PR is to add the email statuses to be mapped to the Sirius statuses that exist as well fixing associated tests and fixing coverage.