### PR TITLE
SW-6017 Create a task following a rejected status in Notify

### DIFF
--- a/docker/mock-notify/openapi.yml
+++ b/docker/mock-notify/openapi.yml
@@ -34,12 +34,14 @@ paths:
                     status: validation-failed
                     id: 9a83b0bb-a534-41a5-849f-dbc39aee4d3d
                     reference: "1234"
+                    type: "email"
                 pending-virus-check:
                   summary: Pending virus check
                   value:
                     status: pending-virus-check
                     id: 9a83b0bb-a534-41a5-849f-dbc39aee4d3d
                     reference: "1234"
+                    type: "email"
         '400':
           description: Error
           content:

--- a/src/NotifyStatusPoller/Command/Handler/UpdateDocumentStatusHandler.php
+++ b/src/NotifyStatusPoller/Command/Handler/UpdateDocumentStatusHandler.php
@@ -41,6 +41,8 @@ class UpdateDocumentStatusHandler
             'documentId' => $command->getDocumentId(),
             'notifySendId' => $command->getNotifyId(),
             'notifyStatus' => $this->notifyStatusMapper->toSirius($command->getNotifyStatus()),
+            'notifySubStatus' => $command->getNotifyStatus(),
+            'sendByMethod' => $command->getSendByMethod()
         ];
 
         $guzzleResponse = $this->guzzleClient->put(

--- a/src/NotifyStatusPoller/Command/Model/UpdateDocumentStatus.php
+++ b/src/NotifyStatusPoller/Command/Model/UpdateDocumentStatus.php
@@ -11,6 +11,7 @@ class UpdateDocumentStatus
     protected int $documentId;
     protected string $notifyId;
     protected string $notifyStatus;
+    protected string $sendByMethod;
 
     /**
      * @param array<string,mixed> $data
@@ -31,11 +32,16 @@ class UpdateDocumentStatus
             AggregateValidationException::addError('Data doesn\'t contain a notifyStatus');
         }
 
+        if (empty($data['sendByMethod'])) {
+            AggregateValidationException::addError('Data doesn\'t contain a sendByMethod');
+        }
+
         AggregateValidationException::checkAndThrow();
 
         $this->documentId = (int)$data['documentId'];
         $this->notifyId = $data['notifyId'];
         $this->notifyStatus = $data['notifyStatus'];
+        $this->sendByMethod = $data['sendByMethod'];
     }
 
     public function getDocumentId(): int
@@ -51,5 +57,10 @@ class UpdateDocumentStatus
     public function getNotifyStatus(): string
     {
         return $this->notifyStatus;
+    }
+
+    public function getSendByMethod(): string
+    {
+        return $this->sendByMethod;
     }
 }

--- a/src/NotifyStatusPoller/Query/Handler/GetNotifyStatusHandler.php
+++ b/src/NotifyStatusPoller/Query/Handler/GetNotifyStatusHandler.php
@@ -37,10 +37,13 @@ class GetNotifyStatusHandler
             throw new NotificationNotFoundException("Notification not found for document ID: " . $query->getDocumentId());
         }
 
-        return new UpdateDocumentStatus([
-            'documentId' => $query->getDocumentId(),
-            'notifyId' => $query->getNotifyId(),
-            'notifyStatus' => $response['status'],
-        ]);
+        return new UpdateDocumentStatus(
+            [
+                'documentId' => $query->getDocumentId(),
+                'notifyId' => $query->getNotifyId(),
+                'notifyStatus' => $response['status'],
+                'sendByMethod' => $response['type'],
+            ]
+        );
     }
 }

--- a/tests/NotifyStatusPollerTest/Unit/Command/Handler/UpdateDocumentStatusHandlerTest.php
+++ b/tests/NotifyStatusPollerTest/Unit/Command/Handler/UpdateDocumentStatusHandlerTest.php
@@ -49,6 +49,8 @@ class UpdateDocumentStatusHandlerTest extends TestCase
             'documentId' => $command->getDocumentId(),
             'notifySendId' => $command->getNotifyId(),
             'notifyStatus' => $siriusStatus,
+            'notifySubStatus' => $command->getNotifyStatus(),
+            'sendByMethod' => 'email',
         ];
 
         $this->mockNotifyStatusMapper
@@ -80,6 +82,8 @@ class UpdateDocumentStatusHandlerTest extends TestCase
             'documentId' => $command->getDocumentId(),
             'notifySendId' => $command->getNotifyId(),
             'notifyStatus' => $siriusStatus,
+            'notifySubStatus' => $command->getNotifyStatus(),
+            'sendByMethod' => 'email'
         ];
 
         $this->mockNotifyStatusMapper
@@ -112,6 +116,7 @@ class UpdateDocumentStatusHandlerTest extends TestCase
             'notifyId' => '1',
             'notifyStatus' => NotifyStatus::ACCEPTED,
             'documentId' => '4545',
+            'sendByMethod' => 'email',
         ]);
     }
 }

--- a/tests/NotifyStatusPollerTest/Unit/Command/Model/UpdateDocumentStatusTest.php
+++ b/tests/NotifyStatusPollerTest/Unit/Command/Model/UpdateDocumentStatusTest.php
@@ -16,6 +16,7 @@ class UpdateDocumentStatusTest extends TestCase
             'notifyId' => '1',
             'notifyStatus' => 'accepted',
             'documentId' => '4545',
+            'sendByMethod' => 'email'
         ];
 
         $command = new UpdateDocumentStatus($data);

--- a/tests/NotifyStatusPollerTest/Unit/Query/Handler/GetNotifyStatusHandlerTest.php
+++ b/tests/NotifyStatusPollerTest/Unit/Query/Handler/GetNotifyStatusHandlerTest.php
@@ -31,6 +31,7 @@ class GetNotifyStatusHandlerTest extends TestCase
         $response = [
             'id' => $getNotifyStatus->getNotifyId(),
             'status' => 'notify-status',
+            'type' => 'email',
         ];
 
         $this->notifyClientMock->expects(self::once())->method('getNotification')->willReturn($response);
@@ -41,6 +42,7 @@ class GetNotifyStatusHandlerTest extends TestCase
         self::assertSame($response['id'], $updateDocumentStatus->getNotifyId());
         self::assertSame($response['status'], $updateDocumentStatus->getNotifyStatus());
         self::assertSame($getNotifyStatus->getNotifyId(), $updateDocumentStatus->getNotifyId());
+        self::assertSame($response['type'], $updateDocumentStatus->getSendByMethod());
     }
 
     public function test_handle_returns_error_when_notification_retrieval_unsuccessful(): void

--- a/tests/NotifyStatusPollerTest/Unit/Runner/JobRunnerTest.php
+++ b/tests/NotifyStatusPollerTest/Unit/Runner/JobRunnerTest.php
@@ -60,11 +60,13 @@ class JobRunnerTest extends TestCase
                 'documentId' => 100,
                 'notifyId' => 'ref-1',
                 'notifyStatus' => 'status-1',
+                'sendByMethod' => 'email',
             ]),
             new UpdateDocumentStatus([
                 'documentId' => 200,
                 'notifyId' => 'ref-2',
                 'notifyStatus' => 'status-2',
+                'sendByMethod' => 'email',
             ]),
         ];
 
@@ -133,11 +135,13 @@ class JobRunnerTest extends TestCase
                 'documentId' => 100,
                 'notifyId' => 'ref-1',
                 'notifyStatus' => 'status-1',
+                'sendByMethod' => 'email',
             ]),
             new UpdateDocumentStatus([
                 'documentId' => 200,
                 'notifyId' => 'ref-2',
                 'notifyStatus' => 'status-2',
+                'sendByMethod' => 'email',
             ]),
         ];
 
@@ -224,11 +228,13 @@ class JobRunnerTest extends TestCase
                 'documentId' => 100,
                 'notifyId' => 'ref-1',
                 'notifyStatus' => 'status-1',
+                'sendByMethod' => 'email',
             ]),
             new UpdateDocumentStatus([
                 'documentId' => 200,
                 'notifyId' => 'ref-2',
                 'notifyStatus' => 'status-2',
+                'sendByMethod' => 'email',
             ]),
         ];
 


### PR DESCRIPTION
#minor 

Following work in SW-5892 to create a review failed automated letter task when an email fails to send for the reasons ‘Inbox not accepting messages right now’ and ‘Email address does not exist’, it was reported that the task was not being automatically created as they were expected to be. 

This appears to be because the poller is responsible for updating a document's status to 'rejected' and not the consumer as originally thought. So the poller needs to send the sendByMethod and the notify status information to sirius to create the task