### PR TITLE
SW-6421 Add email address to task description when email address fails validation

### DIFF
--- a/docker/mock-notify/openapi.yml
+++ b/docker/mock-notify/openapi.yml
@@ -35,6 +35,7 @@ paths:
                     id: 9a83b0bb-a534-41a5-849f-dbc39aee4d3d
                     reference: "1234"
                     type: "email"
+                    email_address: "test@test.com"
                 pending-virus-check:
                   summary: Pending virus check
                   value:
@@ -42,6 +43,7 @@ paths:
                     id: 9a83b0bb-a534-41a5-849f-dbc39aee4d3d
                     reference: "1234"
                     type: "email"
+                    email_address: "test@test.com"
         '400':
           description: Error
           content:

--- a/public/job_runner.php
+++ b/public/job_runner.php
@@ -19,6 +19,7 @@ require_once __DIR__ . '/../src/bootstrap/logging.php';
 try {
     require_once __DIR__ . '/../src/bootstrap/services.php';
 
+    /** @phpstan-ignore-next-line */
     while ($doRunLoop) {
         $jobRunner->run();
 

--- a/src/NotifyStatusPoller/Command/Handler/UpdateDocumentStatusHandler.php
+++ b/src/NotifyStatusPoller/Command/Handler/UpdateDocumentStatusHandler.php
@@ -42,7 +42,8 @@ class UpdateDocumentStatusHandler
             'notifySendId' => $command->getNotifyId(),
             'notifyStatus' => $this->notifyStatusMapper->toSirius($command->getNotifyStatus()),
             'notifySubStatus' => $command->getNotifyStatus(),
-            'sendByMethod' => $command->getSendByMethod()
+            'sendByMethod' => $command->getSendByMethod(),
+            'recipientEmailAddress' => $command->getRecipientEmailAddress()
         ];
 
         $guzzleResponse = $this->guzzleClient->put(

--- a/src/NotifyStatusPoller/Command/Model/UpdateDocumentStatus.php
+++ b/src/NotifyStatusPoller/Command/Model/UpdateDocumentStatus.php
@@ -12,7 +12,7 @@ class UpdateDocumentStatus
     protected string $notifyId;
     protected string $notifyStatus;
     protected string $sendByMethod;
-    protected string $recipientEmailAddress;
+    protected ?string $recipientEmailAddress;
 
     /**
      * @param array<string,mixed> $data
@@ -35,10 +35,6 @@ class UpdateDocumentStatus
 
         if (empty($data['sendByMethod'])) {
             AggregateValidationException::addError('Data doesn\'t contain a sendByMethod');
-        }
-
-        if (empty($data['recipientEmailAddress'])) {
-            AggregateValidationException::addError('Data doesn\'t contain a recipientEmailAddress');
         }
 
         AggregateValidationException::checkAndThrow();
@@ -70,7 +66,7 @@ class UpdateDocumentStatus
         return $this->sendByMethod;
     }
 
-    public function getRecipientEmailAddress(): string
+    public function getRecipientEmailAddress(): ?string
     {
         return $this->recipientEmailAddress;
     }

--- a/src/NotifyStatusPoller/Command/Model/UpdateDocumentStatus.php
+++ b/src/NotifyStatusPoller/Command/Model/UpdateDocumentStatus.php
@@ -12,6 +12,7 @@ class UpdateDocumentStatus
     protected string $notifyId;
     protected string $notifyStatus;
     protected string $sendByMethod;
+    protected string $recipientEmailAddress;
 
     /**
      * @param array<string,mixed> $data
@@ -36,12 +37,17 @@ class UpdateDocumentStatus
             AggregateValidationException::addError('Data doesn\'t contain a sendByMethod');
         }
 
+        if (empty($data['recipientEmailAddress'])) {
+            AggregateValidationException::addError('Data doesn\'t contain a recipientEmailAddress');
+        }
+
         AggregateValidationException::checkAndThrow();
 
         $this->documentId = (int)$data['documentId'];
         $this->notifyId = $data['notifyId'];
         $this->notifyStatus = $data['notifyStatus'];
         $this->sendByMethod = $data['sendByMethod'];
+        $this->recipientEmailAddress = $data['recipientEmailAddress'];
     }
 
     public function getDocumentId(): int
@@ -62,5 +68,10 @@ class UpdateDocumentStatus
     public function getSendByMethod(): string
     {
         return $this->sendByMethod;
+    }
+
+    public function getRecipientEmailAddress(): string
+    {
+        return $this->recipientEmailAddress;
     }
 }

--- a/src/NotifyStatusPoller/Query/Handler/GetNotifyStatusHandler.php
+++ b/src/NotifyStatusPoller/Query/Handler/GetNotifyStatusHandler.php
@@ -43,6 +43,7 @@ class GetNotifyStatusHandler
                 'notifyId' => $query->getNotifyId(),
                 'notifyStatus' => $response['status'],
                 'sendByMethod' => $response['type'],
+                'recipientEmailAddress' => $response['recipientEmailAddress']
             ]
         );
     }

--- a/src/NotifyStatusPoller/Query/Handler/GetNotifyStatusHandler.php
+++ b/src/NotifyStatusPoller/Query/Handler/GetNotifyStatusHandler.php
@@ -43,7 +43,7 @@ class GetNotifyStatusHandler
                 'notifyId' => $query->getNotifyId(),
                 'notifyStatus' => $response['status'],
                 'sendByMethod' => $response['type'],
-                'recipientEmailAddress' => $response['recipientEmailAddress']
+                'recipientEmailAddress' => $response['email_address']
             ]
         );
     }

--- a/src/NotifyStatusPoller/Query/Handler/GetNotifyStatusHandler.php
+++ b/src/NotifyStatusPoller/Query/Handler/GetNotifyStatusHandler.php
@@ -43,7 +43,7 @@ class GetNotifyStatusHandler
                 'notifyId' => $query->getNotifyId(),
                 'notifyStatus' => $response['status'],
                 'sendByMethod' => $response['type'],
-                'recipientEmailAddress' => $response['email_address']
+                'recipientEmailAddress' => $response['email_address'] ?? null
             ]
         );
     }

--- a/tests/NotifyStatusPollerTest/Unit/Command/Handler/UpdateDocumentStatusHandlerTest.php
+++ b/tests/NotifyStatusPollerTest/Unit/Command/Handler/UpdateDocumentStatusHandlerTest.php
@@ -50,7 +50,8 @@ class UpdateDocumentStatusHandlerTest extends TestCase
             'notifySendId' => $command->getNotifyId(),
             'notifyStatus' => $siriusStatus,
             'notifySubStatus' => $command->getNotifyStatus(),
-            'sendByMethod' => 'email',
+            'sendByMethod' => $command->getSendByMethod(),
+            'recipientEmailAddress' => $command->getRecipientEmailAddress()
         ];
 
         $this->mockNotifyStatusMapper
@@ -83,7 +84,8 @@ class UpdateDocumentStatusHandlerTest extends TestCase
             'notifySendId' => $command->getNotifyId(),
             'notifyStatus' => $siriusStatus,
             'notifySubStatus' => $command->getNotifyStatus(),
-            'sendByMethod' => 'email'
+            'sendByMethod' => $command->getSendByMethod(),
+            'recipientEmailAddress' => $command->getRecipientEmailAddress()
         ];
 
         $this->mockNotifyStatusMapper
@@ -117,6 +119,7 @@ class UpdateDocumentStatusHandlerTest extends TestCase
             'notifyStatus' => NotifyStatus::ACCEPTED,
             'documentId' => '4545',
             'sendByMethod' => 'email',
+            'recipientEmailAddress' => 'test@test.com'
         ]);
     }
 }

--- a/tests/NotifyStatusPollerTest/Unit/Command/Model/UpdateDocumentStatusTest.php
+++ b/tests/NotifyStatusPollerTest/Unit/Command/Model/UpdateDocumentStatusTest.php
@@ -16,7 +16,8 @@ class UpdateDocumentStatusTest extends TestCase
             'notifyId' => '1',
             'notifyStatus' => 'accepted',
             'documentId' => '4545',
-            'sendByMethod' => 'email'
+            'sendByMethod' => 'email',
+            'recipientEmailAddress' => 'test@test.com'
         ];
 
         $command = new UpdateDocumentStatus($data);
@@ -57,6 +58,14 @@ class UpdateDocumentStatusTest extends TestCase
                 ['notifyId' => '1', 'notifyStatus' => 'accepted'],
                 'Data doesn\'t contain a numeric documentId'
             ],
+            'missing sendByMethod' => [
+                ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => '4545', 'recipientEmailAddress' => 'test@test.com'],
+                'Data doesn\'t contain a sendByMethod'
+            ],
+            'missing recipientEmailAddress' => [
+                ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => '4545', 'sendByMethod' => 'email'],
+                'Data doesn\'t contain a recipientEmailAddress'
+            ],
             'non-numeric documentId' => [
                 ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => 'word'],
                 'Data doesn\'t contain a numeric documentId'
@@ -67,6 +76,8 @@ class UpdateDocumentStatusTest extends TestCase
                         'Data doesn\'t contain a numeric documentId',
                         'Data doesn\'t contain a notifyId',
                         'Data doesn\'t contain a notifyStatus',
+                        'Data doesn\'t contain a sendByMethod',
+                        'Data doesn\'t contain a recipientEmailAddress',
                     ]
                 ),
             ],

--- a/tests/NotifyStatusPollerTest/Unit/Command/Model/UpdateDocumentStatusTest.php
+++ b/tests/NotifyStatusPollerTest/Unit/Command/Model/UpdateDocumentStatusTest.php
@@ -10,7 +10,7 @@ use NotifyStatusPoller\Command\Model\UpdateDocumentStatus;
 
 class UpdateDocumentStatusTest extends TestCase
 {
-    public function testFromArraySuccess(): void
+    public function testFromArraySuccessSupervision(): void
     {
         $data = [
             'notifyId' => '1',
@@ -25,6 +25,27 @@ class UpdateDocumentStatusTest extends TestCase
         self::assertEquals($data['notifyId'], $command->getNotifyId());
         self::assertEquals($data['notifyStatus'], $command->getNotifyStatus());
         self::assertEquals($data['documentId'], $command->getDocumentId());
+        self::assertEquals($data['sendByMethod'], $command->getSendByMethod());
+        self::assertEquals($data['recipientEmailAddress'], $command->getRecipientEmailAddress());
+    }
+
+    public function testFromArraySuccessLpa(): void
+    {
+        $data = [
+            'notifyId' => '1',
+            'notifyStatus' => 'accepted',
+            'documentId' => '4545',
+            'sendByMethod' => 'post',
+            'recipientEmailAddress' => null
+        ];
+
+        $command = new UpdateDocumentStatus($data);
+
+        self::assertEquals($data['notifyId'], $command->getNotifyId());
+        self::assertEquals($data['notifyStatus'], $command->getNotifyStatus());
+        self::assertEquals($data['documentId'], $command->getDocumentId());
+        self::assertEquals($data['sendByMethod'], $command->getSendByMethod());
+        self::assertEquals($data['recipientEmailAddress'], $command->getRecipientEmailAddress());
     }
 
     /**
@@ -62,22 +83,17 @@ class UpdateDocumentStatusTest extends TestCase
                 ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => '4545', 'recipientEmailAddress' => 'test@test.com'],
                 'Data doesn\'t contain a sendByMethod'
             ],
-            'missing recipientEmailAddress' => [
-                ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => '4545', 'sendByMethod' => 'email'],
-                'Data doesn\'t contain a recipientEmailAddress'
-            ],
             'non-numeric documentId' => [
                 ['notifyId' => '1', 'notifyStatus' => 'accepted', 'documentId' => 'word'],
                 'Data doesn\'t contain a numeric documentId'
             ],
-            'missing all' => [
+            'missing mandatory' => [
                 [],
                 implode(', ', [
                         'Data doesn\'t contain a numeric documentId',
                         'Data doesn\'t contain a notifyId',
                         'Data doesn\'t contain a notifyStatus',
-                        'Data doesn\'t contain a sendByMethod',
-                        'Data doesn\'t contain a recipientEmailAddress',
+                        'Data doesn\'t contain a sendByMethod'
                     ]
                 ),
             ],

--- a/tests/NotifyStatusPollerTest/Unit/Query/Handler/GetNotifyStatusHandlerTest.php
+++ b/tests/NotifyStatusPollerTest/Unit/Query/Handler/GetNotifyStatusHandlerTest.php
@@ -32,6 +32,7 @@ class GetNotifyStatusHandlerTest extends TestCase
             'id' => $getNotifyStatus->getNotifyId(),
             'status' => 'notify-status',
             'type' => 'email',
+            'email_address' => 'test@test.com'
         ];
 
         $this->notifyClientMock->expects(self::once())->method('getNotification')->willReturn($response);
@@ -43,6 +44,7 @@ class GetNotifyStatusHandlerTest extends TestCase
         self::assertSame($response['status'], $updateDocumentStatus->getNotifyStatus());
         self::assertSame($getNotifyStatus->getNotifyId(), $updateDocumentStatus->getNotifyId());
         self::assertSame($response['type'], $updateDocumentStatus->getSendByMethod());
+        self::assertSame($response['email_address'], $updateDocumentStatus->getRecipientEmailAddress());
     }
 
     public function test_handle_returns_error_when_notification_retrieval_unsuccessful(): void

--- a/tests/NotifyStatusPollerTest/Unit/Query/Handler/GetNotifyStatusHandlerTest.php
+++ b/tests/NotifyStatusPollerTest/Unit/Query/Handler/GetNotifyStatusHandlerTest.php
@@ -21,7 +21,7 @@ class GetNotifyStatusHandlerTest extends TestCase
         $this->notifyClientMock = $this->createMock(NotifyClient::class);
     }
 
-    public function test_handle_returns_populated_model_on_success(): void
+    public function test_handle_returns_populated_model_on_supervision_success(): void
     {
         $getNotifyStatus = new GetNotifyStatus([
             'documentId' => '1234',
@@ -45,6 +45,31 @@ class GetNotifyStatusHandlerTest extends TestCase
         self::assertSame($getNotifyStatus->getNotifyId(), $updateDocumentStatus->getNotifyId());
         self::assertSame($response['type'], $updateDocumentStatus->getSendByMethod());
         self::assertSame($response['email_address'], $updateDocumentStatus->getRecipientEmailAddress());
+    }
+
+    public function test_handle_returns_populated_model_on_lpa_success(): void
+    {
+        $getNotifyStatus = new GetNotifyStatus([
+            'documentId' => '1234',
+            'notifyId' => '1234',
+        ]);
+        $handler = new GetNotifyStatusHandler($this->notifyClientMock);
+        $response = [
+            'id' => $getNotifyStatus->getNotifyId(),
+            'status' => 'notify-status',
+            'type' => 'letter'
+        ];
+
+        $this->notifyClientMock->expects(self::once())->method('getNotification')->willReturn($response);
+
+        $updateDocumentStatus = $handler->handle($getNotifyStatus);
+
+        self::assertInstanceOf(UpdateDocumentStatus::class, $updateDocumentStatus);
+        self::assertSame($response['id'], $updateDocumentStatus->getNotifyId());
+        self::assertSame($response['status'], $updateDocumentStatus->getNotifyStatus());
+        self::assertSame($getNotifyStatus->getNotifyId(), $updateDocumentStatus->getNotifyId());
+        self::assertSame($response['type'], $updateDocumentStatus->getSendByMethod());
+        self::assertSame(null, $updateDocumentStatus->getRecipientEmailAddress());
     }
 
     public function test_handle_returns_error_when_notification_retrieval_unsuccessful(): void

--- a/tests/NotifyStatusPollerTest/Unit/Runner/JobRunnerTest.php
+++ b/tests/NotifyStatusPollerTest/Unit/Runner/JobRunnerTest.php
@@ -61,12 +61,14 @@ class JobRunnerTest extends TestCase
                 'notifyId' => 'ref-1',
                 'notifyStatus' => 'status-1',
                 'sendByMethod' => 'email',
+                'recipientEmailAddress' => 'test@test.com'
             ]),
             new UpdateDocumentStatus([
                 'documentId' => 200,
                 'notifyId' => 'ref-2',
                 'notifyStatus' => 'status-2',
                 'sendByMethod' => 'email',
+                'recipientEmailAddress' => 'test@test.com'
             ]),
         ];
 
@@ -136,12 +138,14 @@ class JobRunnerTest extends TestCase
                 'notifyId' => 'ref-1',
                 'notifyStatus' => 'status-1',
                 'sendByMethod' => 'email',
+                'recipientEmailAddress' => 'test@test.com'
             ]),
             new UpdateDocumentStatus([
                 'documentId' => 200,
                 'notifyId' => 'ref-2',
                 'notifyStatus' => 'status-2',
                 'sendByMethod' => 'email',
+                'recipientEmailAddress' => 'test@test.com'
             ]),
         ];
 
@@ -229,12 +233,14 @@ class JobRunnerTest extends TestCase
                 'notifyId' => 'ref-1',
                 'notifyStatus' => 'status-1',
                 'sendByMethod' => 'email',
+                'recipientEmailAddress' => 'test@test.com'
             ]),
             new UpdateDocumentStatus([
                 'documentId' => 200,
                 'notifyId' => 'ref-2',
                 'notifyStatus' => 'status-2',
                 'sendByMethod' => 'email',
+                'recipientEmailAddress' => 'test@test.com'
             ]),
         ];
 


### PR DESCRIPTION
This PR is to add the email address of the recipient to the tasks where their email fails validation from Notify. This adds the functionality to send the email address back to Sirius where Notify deems that the email address does not exist / or is not receiving emails currently.